### PR TITLE
use COPY instead of ADD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM telegraf:1.7
 
 LABEL maintainer="team@appwrite.io"
 
-ADD ./telegraf.conf /etc/telegraf/telegraf.conf
+COPY ./telegraf.conf /etc/telegraf/telegraf.conf


### PR DESCRIPTION
`COPY` is preferable over `ADD` when copying files.