### PR TITLE
Update Telegraf version to 1.20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.14
 
 LABEL maintainer="team@appwrite.io"
 


### PR DESCRIPTION
This PR Updates Telegraf to 1.20.2 from 1.18.2.

Testing
Telegraf image was built and tested in the Appwrite stack.